### PR TITLE
Add image logic to theme-b-image-only-header block

### DIFF
--- a/packages/common/components/style-b/blocks/image-only-header.marko
+++ b/packages/common/components/style-b/blocks/image-only-header.marko
@@ -29,8 +29,9 @@ $ const dateStyle = defaultValue(input.dateStyle, "text-transform: uppercase; co
       </td>
     </tr>
     <if('hide' !== config.dateToggle)>
+      $ const configDateStyle = config.headerTextColor ? `${dateStyle} color: ${config.headerTextColor}` : dateStyle;
       <tr>
-        <td style=dateStyle>
+        <td style=configDateStyle>
           ${date.format(config.dateToggle)}
         </td>
       </tr>

--- a/packages/common/components/style-b/blocks/image-only-header.marko
+++ b/packages/common/components/style-b/blocks/image-only-header.marko
@@ -28,11 +28,13 @@ $ const dateStyle = defaultValue(input.dateStyle, "text-transform: uppercase; co
         </else>
       </td>
     </tr>
-    <tr>
-      <td style=dateStyle>
-        ${date.format("MMMM D, YYYY")}
-      </td>
-    </tr>
+    <if('hide' !== config.dateToggle)>
+      <tr>
+        <td style=dateStyle>
+          ${date.format(config.dateToggle)}
+        </td>
+      </tr>
+    </if>
   </common-table>
 </if>
 <else>

--- a/packages/common/components/style-b/blocks/image-only-header.marko
+++ b/packages/common/components/style-b/blocks/image-only-header.marko
@@ -17,7 +17,7 @@ $ const dateStyle = defaultValue(input.dateStyle, "text-transform: uppercase; co
       <td>&nbsp;</td>
     </tr>
     <tr>
-      <td bgcolor=config.headerBgColor align="right">
+      <td bgcolor=config.headerBgColor>
         <common-style-b-config-header-images config=config alt=newsletter.name newsletter=newsletter/>
       </td>
     </tr>

--- a/packages/common/components/style-b/blocks/image-only-header.marko
+++ b/packages/common/components/style-b/blocks/image-only-header.marko
@@ -17,15 +17,8 @@ $ const dateStyle = defaultValue(input.dateStyle, "text-transform: uppercase; co
       <td>&nbsp;</td>
     </tr>
     <tr>
-      <td bgcolor=config.headerBgColor>
-        <if(config.headerLink)>
-          <a href=config.headerLink alt=newsletter.name>
-            <common-style-b-config-header-images config=config alt=newsletter.name />
-          </a>
-        </if>
-        <else>
-          <common-style-b-config-header-images config=config alt=newsletter.name/>
-        </else>
+      <td bgcolor=config.headerBgColor align="right">
+        <common-style-b-config-header-images config=config alt=newsletter.name newsletter=newsletter/>
       </td>
     </tr>
     <if('hide' !== config.dateToggle)>

--- a/packages/common/components/style-b/blocks/image-only-header.marko
+++ b/packages/common/components/style-b/blocks/image-only-header.marko
@@ -1,4 +1,5 @@
 import defaultValue from "@base-cms/marko-core/utils/default-value";
+import { getAsArray, getAsObject } from "@base-cms/object-path";
 
 $ const {
   newsletter,
@@ -6,28 +7,56 @@ $ const {
   imagePath
 } = input;
 
+$ const alphaThemeConfigs = getAsArray(newsletter, 'alphaThemeConfigs.edges');
+$ const config = alphaThemeConfigs[0] ? getAsObject(alphaThemeConfigs[0], 'node') : null;
 $ const dateStyle = defaultValue(input.dateStyle, "text-transform: uppercase; color: #6b6b6b; font: 700 12px/18px Helvetica, 'Helvetica Neue', Arial, sans-serif;");
 
-<common-table width="700" style="border-collapse:collapse;" align="center" class="main header image-only-header" padding=0 spacing=0>
-  <tr>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>
-      <span>
-        <marko-newsletter-imgix
-          src=imagePath
-          alt=newsletter.name
-          options={ w: 700 }
-          attrs={ border: 0, width: 700 }
-        >
-        </marko-newsletter-imgix>
-      </span>
-    </td>
-  </tr>
-  <tr>
-    <td style=dateStyle>
-      ${date.format("MMMM D, YYYY")}
-    </td>
-  </tr>
-</common-table>
+<if(config.headerLeft)>
+  <common-table width="700" style="border-collapse:collapse;" align="center" class="main header image-only-header" padding=0 spacing=0>
+    <tr>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td bgcolor=config.headerBgColor>
+        <if(config.headerLink)>
+          <a href=config.headerLink alt=newsletter.name>
+            <common-style-b-config-header-images config=config alt=newsletter.name />
+          </a>
+        </if>
+        <else>
+          <common-style-b-config-header-images config=config alt=newsletter.name/>
+        </else>
+      </td>
+    </tr>
+    <tr>
+      <td style=dateStyle>
+        ${date.format("MMMM D, YYYY")}
+      </td>
+    </tr>
+  </common-table>
+</if>
+<else>
+  <common-table width="700" style="border-collapse:collapse;" align="center" class="main header image-only-header" padding=0 spacing=0>
+    <tr>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>
+        <span>
+          <marko-newsletter-imgix
+            src=imagePath
+            alt=newsletter.name
+            options={ w: 700 }
+            attrs={ border: 0, width: 700 }
+          >
+          </marko-newsletter-imgix>
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <td style=dateStyle>
+        ${date.format("MMMM D, YYYY")}
+      </td>
+    </tr>
+  </common-table>
+</else>

--- a/packages/common/components/style-b/elements/config-header-images.marko
+++ b/packages/common/components/style-b/elements/config-header-images.marko
@@ -1,0 +1,35 @@
+$ const { config, alt } = input;
+
+<if(config)>
+  <if(config.headerTemplate === 'image-full-700px')>
+    <span>
+      <marko-newsletter-imgix
+        src=config.headerLeft.src
+        alt=alt
+        options={ w: 700 }
+        attrs={ border: 0, width: 700 }
+      >
+      </marko-newsletter-imgix>
+    </span>
+  </if>
+  <else>
+    <span>
+      <marko-newsletter-imgix
+        src=config.headerLeft.src
+        alt=alt
+        options={ w: 350 }
+        attrs={ border: 0, align: 'left', width: 350 }
+      >
+      </marko-newsletter-imgix>
+      <if(config.headerRight && config.headerRight.src)>
+      <marko-newsletter-imgix
+        src=config.headerRight.src
+        alt=alt
+        options={ w: 350 }
+        attrs={ border: 0, align: 'left', width: 350 }
+      >
+      </marko-newsletter-imgix>
+      </if>
+    </span>
+  </else>
+</if>

--- a/packages/common/components/style-b/elements/config-header-images.marko
+++ b/packages/common/components/style-b/elements/config-header-images.marko
@@ -1,35 +1,41 @@
-$ const { config, alt } = input;
+$ const { config, alt, newsletter } = input;
 
 <if(config)>
   <if(config.headerTemplate === 'image-full-700px')>
     <span>
-      <marko-newsletter-imgix
-        src=config.headerLeft.src
-        alt=alt
-        options={ w: 700 }
-        attrs={ border: 0, width: 700 }
-      >
+        <marko-newsletter-imgix
+          src=config.headerLeft.src
+          alt=alt
+          options={ w: 700 }
+          attrs={ border: 0, width: 700 }
+        >
+          <@link href=config.headerLink title=alt target="_blank" />
       </marko-newsletter-imgix>
     </span>
   </if>
   <else>
-    <span>
-      <marko-newsletter-imgix
-        src=config.headerLeft.src
-        alt=alt
-        options={ w: 350 }
-        attrs={ border: 0, align: 'left', width: 350 }
-      >
-      </marko-newsletter-imgix>
-      <if(config.headerRight && config.headerRight.src)>
-      <marko-newsletter-imgix
-        src=config.headerRight.src
-        alt=alt
-        options={ w: 350 }
-        attrs={ border: 0, align: 'left', width: 350 }
-      >
-      </marko-newsletter-imgix>
-      </if>
-    </span>
+    <marko-newsletter-imgix
+      src=config.headerLeft.src
+      alt=alt
+      options={ w: 350 }
+      attrs={ border: 0, align: 'left', width: 350 }
+    >
+      <@link href=config.headerLink title=alt target="_blank" />
+    </marko-newsletter-imgix>
+    <if(config.headerRight && config.headerRight.src)>
+    <marko-newsletter-imgix
+      src=config.headerRight.src
+      alt=alt
+      options={ w: 350 }
+      attrs={ border: 0, align: 'left', width: 350 }
+    >
+      <@link href=config.headerLink title=alt target="_blank" />
+    </marko-newsletter-imgix>
+    </if>
+    <else>
+      <div style="padding-top: 10px;">
+        <common-social-icons-element newsletter=newsletter/>
+      </div>
+    </else>
   </else>
 </if>

--- a/packages/common/components/style-b/elements/marko.json
+++ b/packages/common/components/style-b/elements/marko.json
@@ -6,5 +6,10 @@
   "<common-style-b-brand-nav-element>": {
     "template": "./brand-nav.marko",
     "@footer-font-style": "string"
+  },
+  "<common-style-b-config-header-images>": {
+    "template": "./config-header-images.marko",
+    "@config": "object",
+    "@alt": "string"
   }
 }

--- a/packages/common/components/style-b/elements/marko.json
+++ b/packages/common/components/style-b/elements/marko.json
@@ -14,6 +14,7 @@
   "<common-style-b-config-header-images>": {
     "template": "./config-header-images.marko",
     "@config": "object",
+    "@newsletter": "object",
     "@alt": "string"
   }
 }


### PR DESCRIPTION
add config based header logic

![Screen Shot 2020-09-16 at 4 32 25 PM](https://user-images.githubusercontent.com/3845869/93394725-47865900-f83a-11ea-9cd2-e87d040198a5.png)

![Screen Shot 2020-09-16 at 4 33 29 PM](https://user-images.githubusercontent.com/3845869/93394795-5f5ddd00-f83a-11ea-925d-cbf817e859f0.png)

![Screen Shot 2020-09-16 at 4 34 04 PM](https://user-images.githubusercontent.com/3845869/93394839-76043400-f83a-11ea-8437-f673ea45573a.png)

![Screen Shot 2020-09-16 at 4 35 23 PM](https://user-images.githubusercontent.com/3845869/93394946-a350e200-f83a-11ea-9307-e15c8d42cb3e.png)

